### PR TITLE
feat: load multiple models

### DIFF
--- a/.github/scripts/e2e-test-llama-linux-and-mac.sh
+++ b/.github/scripts/e2e-test-llama-linux-and-mac.sh
@@ -45,6 +45,7 @@ response1=$(curl --connect-timeout 60 -o /tmp/response1.log -s -w "%{http_code}"
     --header 'Content-Type: application/json' \
     --data '{
     "llama_model_path": "/tmp/testllm",
+    "model_alias": "gpt-3.5-turbo",
     "ctx_len": 50,
     "ngl": 32,
     "embedding": false

--- a/.github/scripts/e2e-test-llama-windows.bat
+++ b/.github/scripts/e2e-test-llama-windows.bat
@@ -53,7 +53,7 @@ if not exist "%MODEL_PATH%" (
 rem Define JSON strings for curl data
 call set "MODEL_PATH_STRING=%%MODEL_PATH:\=\\%%"
 set "curl_data1={\"llama_model_path\":\"%MODEL_PATH_STRING%\"}"
-set "curl_data2={\"messages\":[{\"content\":\"Hello there\",\"role\":\"assistant\"},{\"content\":\"Write a long and sad story for me\",\"role\":\"user\"}],\"stream\":true,\"model\":\"gpt-3.5-turbo\",\"max_tokens\":50,\"stop\":[\"hello\"],\"frequency_penalty\":0,\"presence_penalty\":0,\"temperature\":0.1}"
+set "curl_data2={\"messages\":[{\"content\":\"Hello there\",\"role\":\"assistant\"},{\"content\":\"Write a long and sad story for me\",\"role\":\"user\"}],\"stream\":true,\"model\":\"testllm\",\"max_tokens\":50,\"stop\":[\"hello\"],\"frequency_penalty\":0,\"presence_penalty\":0,\"temperature\":0.1}"
 
 rem Print the values of curl_data1 and curl_data2 for debugging
 echo curl_data1=%curl_data1%

--- a/controllers/llamaCPP.h
+++ b/controllers/llamaCPP.h
@@ -92,8 +92,9 @@ class llamaCPP : public drogon::HttpController<llamaCPP>,
   /**
    * Queue to handle the inference tasks
    */
-  int task_queue_thread_num = 1;
-  std::unique_ptr<trantor::ConcurrentTaskQueue> inference_task_queue;
+  // TODO: should we move this to server_context?
+  std::unordered_map<std::string, std::unique_ptr<trantor::ConcurrentTaskQueue>>
+      ifr_task_queue_map;
 
   bool LoadModelImpl(std::shared_ptr<Json::Value> jsonBody);
   void InferenceImpl(inferences::ChatCompletionRequest&& completion,

--- a/models/chat_completion_request.h
+++ b/models/chat_completion_request.h
@@ -11,6 +11,7 @@ struct ChatCompletionRequest {
   float presence_penalty = 0;
   Json::Value stop = Json::Value(Json::arrayValue);
   Json::Value messages = Json::Value(Json::arrayValue);
+  std::string model_id;
 };
 }  // namespace inferences
 
@@ -30,6 +31,7 @@ inline inferences::ChatCompletionRequest fromRequest(const HttpRequest& req) {
         (*jsonBody).get("presence_penalty", 0).asFloat();
     completion.messages = (*jsonBody)["messages"];
     completion.stop = (*jsonBody)["stop"];
+    completion.model_id = (*jsonBody).get("model", {}).asString();
   }
   return completion;
 }

--- a/test/components/test_nitro_utils.cc
+++ b/test/components/test_nitro_utils.cc
@@ -1,41 +1,113 @@
 #include "gtest/gtest.h"
 #include "utils/nitro_utils.h"
 
-class NitroUtilTest : public ::testing::Test {
-};
+class NitroUtilTest : public ::testing::Test {};
 
 TEST_F(NitroUtilTest, left_trim) {
-    {
-        std::string empty;
-        nitro_utils::ltrim(empty);
-        EXPECT_EQ(empty, "");
-    }
+  {
+    std::string empty;
+    nitro_utils::ltrim(empty);
+    EXPECT_EQ(empty, "");
+  }
 
-    {
-        std::string s = "abc";
-        std::string expected = "abc";
-        nitro_utils::ltrim(s);
-        EXPECT_EQ(s, expected);
-    }
+  {
+    std::string s = "abc";
+    std::string expected = "abc";
+    nitro_utils::ltrim(s);
+    EXPECT_EQ(s, expected);
+  }
 
-    {
-        std::string s = " abc";
-        std::string expected = "abc";
-        nitro_utils::ltrim(s);
-        EXPECT_EQ(s, expected);
-    }
+  {
+    std::string s = " abc";
+    std::string expected = "abc";
+    nitro_utils::ltrim(s);
+    EXPECT_EQ(s, expected);
+  }
 
-    {
-        std::string s = "1 abc 2 ";
-        std::string expected = "1 abc 2 ";
-        nitro_utils::ltrim(s);
-        EXPECT_EQ(s, expected);
-    }
+  {
+    std::string s = "1 abc 2 ";
+    std::string expected = "1 abc 2 ";
+    nitro_utils::ltrim(s);
+    EXPECT_EQ(s, expected);
+  }
 
-    {
-        std::string s = " |abc";
-        std::string expected = "|abc";
-        nitro_utils::ltrim(s);
-        EXPECT_EQ(s, expected);
-    }
+  {
+    std::string s = " |abc";
+    std::string expected = "|abc";
+    nitro_utils::ltrim(s);
+    EXPECT_EQ(s, expected);
+  }
+}
+
+TEST_F(NitroUtilTest, get_model_id) {
+  // linux
+  {
+    Json::Value data;
+    data["llama_model_path"] =
+        "e:/workspace/model/"
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS.gguf";
+    std::string expected =
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  {
+    Json::Value data;
+    data["llama_model_path"] =
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS.gguf";
+    std::string expected =
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  // windows
+  {
+    Json::Value data;
+    data["llama_model_path"] =
+        "e:\\workspace\\model\\"
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS.gguf";
+    std::string expected =
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  {
+    Json::Value data;
+    data["llama_model_path"] =
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    std::string expected = "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  {
+    Json::Value data;
+    data["llama_model_path"] = "";
+    data["model_alias"] =
+        "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    std::string expected = "Starling_Monarch_Westlake_Garten-7B-v0.1-IQ4_XS";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  {
+    Json::Value data;
+    data["llama_model_path"] = "";
+    std::string expected = "";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  // For embedding request
+  {
+    Json::Value data;
+    data["model"] =
+        "nomic-embed-text-v1.5.f16";
+    std::string expected = "nomic-embed-text-v1.5.f16";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
+
+  {
+    Json::Value data;
+    data["llama_model_path"] = "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\testllm";
+    std::string expected = "testllm";
+    EXPECT_EQ(nitro_utils::getModelId(data), expected);
+  }
 }

--- a/utils/nitro_utils.h
+++ b/utils/nitro_utils.h
@@ -296,7 +296,7 @@ inline std::string getModelId(const Json::Value& jsonBody) {
     auto s = input.asString();
     std::replace(s.begin(), s.end(), '\\', '/');
     auto const pos = s.find_last_of('/');
-    // We only if file name has gguf extension or nothing
+    // We only truncate the extension if file name has gguf extension
     if(s.substr(s.find_last_of('.') + 1) == "gguf") {
       return s.substr(pos + 1, s.find_last_of('.') - pos - 1);
     } else {


### PR DESCRIPTION
Issue link: https://github.com/janhq/nitro/issues/467
- use std::unordered_map to store all llama_server_context (lsc)
- refactor: move background thread to lsc, each lsc has its own background thread
- TODO: update documentation

We use mode_id as a key to find the model, so they have to be unique. That requires some changes in request parameter:
For completions:
Have to set value the model_alias for `inferences/llamaCPP/loadmodel` and `inferences/llamaCPP/unloadmodel` , this has to be the same as model parameter in `inferences/llamaCPP/chat_completion` 
loadmodel/unloadmodel:
```
{
...
 "llama_model_path": "file_to_location"
  "model_alias": "model1"
...
}
```
chat_completion:
```
{
...
  "model": "model1"  
...
}
```
For embeddings:
The same for loadmodel/unloadmodel, for embedding request, we need to add model parameter
loadmodel/unloadmodel
```
{
...
    "llama_model_path": "e:/workspace/model/nomic-embed-text-v1.5.f16.gguf",
    "model_alias": "model1",
    "model_type": "embedding"
...
}
```
embedding
```
{
...  
  "input": "how are you",
  "model": "model1"
...
}
```