### PR TITLE
feat: get running models

### DIFF
--- a/cortex-cpp/common/base.h
+++ b/cortex-cpp/common/base.h
@@ -16,6 +16,9 @@ class BaseModel {
   virtual void ModelStatus(
       const HttpRequestPtr& req,
       std::function<void(const HttpResponsePtr&)>&& callback) = 0;
+  
+  virtual void GetModels(const HttpRequestPtr& req,
+      std::function<void(const HttpResponsePtr&)>&& callback) = 0;
 };
 
 class BaseChatCompletion {

--- a/cortex-cpp/controllers/server.h
+++ b/cortex-cpp/controllers/server.h
@@ -46,9 +46,12 @@ class server : public drogon::HttpController<server>,
   METHOD_ADD(server::LoadModel, "loadmodel", Post);
   METHOD_ADD(server::UnloadModel, "unloadmodel", Post);
   METHOD_ADD(server::ModelStatus, "modelstatus", Post);
+  METHOD_ADD(server::GetModels, "models", Get);
+  
 
   // Openai compatible path
   ADD_METHOD_TO(server::ChatCompletion, "/v1/chat/completions", Post);
+  ADD_METHOD_TO(server::GetModels, "/v1/models", Get);
   // ADD_METHOD_TO(server::handlePrelight, "/v1/chat/completions", Options);
   // NOTE: prelight will be added back when browser support is properly planned
 
@@ -70,6 +73,9 @@ class server : public drogon::HttpController<server>,
       const HttpRequestPtr& req,
       std::function<void(const HttpResponsePtr&)>&& callback) override;
   void ModelStatus(
+      const HttpRequestPtr& req,
+      std::function<void(const HttpResponsePtr&)>&& callback) override;
+  void GetModels(
       const HttpRequestPtr& req,
       std::function<void(const HttpResponsePtr&)>&& callback) override;
 

--- a/cortex-cpp/cortex-common/EngineI.h
+++ b/cortex-cpp/cortex-common/EngineI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <iostream>
 #include <memory>
 
 #include "json/value.h"
@@ -24,4 +25,12 @@ class EngineI {
   virtual void GetModelStatus(
       std::shared_ptr<Json::Value> jsonBody,
       std::function<void(Json::Value&&, Json::Value&&)>&& callback) = 0;
+
+  // Get list of running models
+  virtual void GetModels(
+      std::shared_ptr<Json::Value> jsonBody,
+      std::function<void(Json::Value&&, Json::Value&&)>&& callback) = 0;
+
+  // For backward compatible checking
+  virtual bool IsSupported(const std::string& f) = 0;
 };


### PR DESCRIPTION
issue: https://github.com/janhq/cortex/issues/589
endpoint: v1/models
response example:
```
{
    "data": [
        {
            "id": "nomic-embed-text-v1.5.f16",
            "object": "model"
        },
        {
            "id": "mistral-7b-instruct-v0.1.Q4_0",
            "object": "model"
        }
    ],
    "object": "list"
}
```

// TODO: bump cortex.llamacpp version to support this