### PR TITLE
feat: add cortex data folder

### DIFF
--- a/cortex-js/package.json
+++ b/cortex-js/package.json
@@ -41,6 +41,7 @@
     "class-validator": "^0.14.1",
     "cli-progress": "^3.12.0",
     "decompress": "^4.2.1",
+    "js-yaml": "^4.1.0",
     "nest-commander": "^3.13.0",
     "readline": "^1.3.0",
     "reflect-metadata": "^0.2.0",
@@ -49,7 +50,6 @@
     "sqlite3": "^5.1.7",
     "typeorm": "^0.3.20",
     "ulid": "^2.3.0",
-    "yaml": "^2.4.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -61,6 +61,7 @@
     "@types/decompress": "^4.2.7",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.12.9",
     "@types/supertest": "^6.0.0",
     "@types/uuid": "^9.0.8",

--- a/cortex-js/src/app.module.ts
+++ b/cortex-js/src/app.module.ts
@@ -11,6 +11,7 @@ import { CortexModule } from './usecases/cortex/cortex.module';
 import { ConfigModule } from '@nestjs/config';
 import { env } from 'node:process';
 import { SeedService } from './usecases/seed/seed.service';
+import { FileManagerModule } from './file-manager/file-manager.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { SeedService } from './usecases/seed/seed.service';
     AssistantsModule,
     CortexModule,
     ExtensionModule,
+    FileManagerModule,
   ],
   providers: [SeedService],
 })

--- a/cortex-js/src/command.module.ts
+++ b/cortex-js/src/command.module.ts
@@ -23,6 +23,7 @@ import { ModelUpdateCommand } from './infrastructure/commanders/models/model-upd
 import { AssistantsModule } from './usecases/assistants/assistants.module';
 import { CliUsecasesModule } from './infrastructure/commanders/usecases/cli.usecases.module';
 import { MessagesModule } from './usecases/messages/messages.module';
+import { FileManagerModule } from './file-manager/file-manager.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { MessagesModule } from './usecases/messages/messages.module';
     CliUsecasesModule,
     AssistantsModule,
     MessagesModule,
+    FileManagerModule,
   ],
   providers: [
     CortexCommand,

--- a/cortex-js/src/domain/config/config.interface.ts
+++ b/cortex-js/src/domain/config/config.interface.ts
@@ -1,0 +1,3 @@
+export interface Config {
+  dataFolderPath: string;
+}

--- a/cortex-js/src/file-manager/file-manager.module.ts
+++ b/cortex-js/src/file-manager/file-manager.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { FileManagerService } from './file-manager.service';
+
+@Module({
+  providers: [FileManagerService],
+  exports: [FileManagerService],
+})
+export class FileManagerModule {}

--- a/cortex-js/src/file-manager/file-manager.service.spec.ts
+++ b/cortex-js/src/file-manager/file-manager.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FileManagerService } from './file-manager.service';
+
+describe('FileManagerService', () => {
+  let service: FileManagerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FileManagerService],
+    }).compile();
+
+    service = module.get<FileManagerService>(FileManagerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/cortex-js/src/file-manager/file-manager.service.ts
+++ b/cortex-js/src/file-manager/file-manager.service.ts
@@ -1,0 +1,78 @@
+import { Config } from '@/domain/config/config.interface';
+import { Injectable } from '@nestjs/common';
+import os from 'os';
+import { join } from 'node:path';
+import { existsSync, promises } from 'node:fs';
+import yaml from 'js-yaml';
+
+@Injectable()
+export class FileManagerService {
+  private configFile = '.cortexrc';
+  private cortexDirectoryName = 'cortex';
+  private modelFolderName = 'models';
+  private cortexCppFolderName = 'cortex-cpp';
+
+  async getConfig(): Promise<Config> {
+    const homeDir = os.homedir();
+    const configPath = join(homeDir, this.configFile);
+
+    if (!existsSync(configPath)) {
+      const config = this.defaultConfig();
+      await this.createFolderIfNotExist(config.dataFolderPath);
+      await this.writeConfigFile(config);
+      return config;
+    }
+
+    try {
+      const content = await promises.readFile(configPath, 'utf8');
+      const config = yaml.load(content) as Config;
+      return config;
+    } catch (error) {
+      console.warn('Error reading config file. Using default config.');
+      console.warn(error);
+      const config = this.defaultConfig();
+      await this.createFolderIfNotExist(config.dataFolderPath);
+      await this.writeConfigFile(config);
+      return config;
+    }
+  }
+
+  private async writeConfigFile(config: Config): Promise<void> {
+    const homeDir = os.homedir();
+    const configPath = join(homeDir, this.configFile);
+
+    // write config to file as yaml
+    const configString = yaml.dump(config);
+    await promises.writeFile(configPath, configString, 'utf8');
+  }
+
+  private async createFolderIfNotExist(dataFolderPath: string): Promise<void> {
+    if (!existsSync(dataFolderPath)) {
+      await promises.mkdir(dataFolderPath, { recursive: true });
+    }
+
+    const modelFolderPath = join(dataFolderPath, this.modelFolderName);
+    const cortexCppFolderPath = join(dataFolderPath, this.cortexCppFolderName);
+    if (!existsSync(modelFolderPath)) {
+      await promises.mkdir(modelFolderPath, { recursive: true });
+    }
+    if (!existsSync(cortexCppFolderPath)) {
+      await promises.mkdir(cortexCppFolderPath, { recursive: true });
+    }
+  }
+
+  private defaultConfig(): Config {
+    // default will store at home directory
+    const homeDir = os.homedir();
+    const dataFolderPath = join(homeDir, this.cortexDirectoryName);
+
+    return {
+      dataFolderPath,
+    };
+  }
+
+  async getDataFolderPath(): Promise<string> {
+    const config = await this.getConfig();
+    return config.dataFolderPath;
+  }
+}

--- a/cortex-js/src/infrastructure/commanders/usecases/cli.usecases.module.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/cli.usecases.module.ts
@@ -9,6 +9,7 @@ import { CortexModule } from '@/usecases/cortex/cortex.module';
 import { ThreadsModule } from '@/usecases/threads/threads.module';
 import { AssistantsModule } from '@/usecases/assistants/assistants.module';
 import { MessagesModule } from '@/usecases/messages/messages.module';
+import { FileManagerModule } from '@/file-manager/file-manager.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { MessagesModule } from '@/usecases/messages/messages.module';
     ThreadsModule,
     AssistantsModule,
     MessagesModule,
+    FileManagerModule,
   ],
   providers: [InitCliUsecases, ModelsCliUsecases, ChatCliUsecases],
   exports: [InitCliUsecases, ModelsCliUsecases, ChatCliUsecases],

--- a/cortex-js/src/infrastructure/database/database.module.ts
+++ b/cortex-js/src/infrastructure/database/database.module.ts
@@ -4,8 +4,10 @@ import { sqliteDatabaseProviders } from './sqlite-database.providers';
 import { modelProviders } from './providers/model.providers';
 import { assistantProviders } from './providers/assistant.providers';
 import { messageProviders } from './providers/message.providers';
+import { FileManagerModule } from '@/file-manager/file-manager.module';
 
 @Module({
+  imports: [FileManagerModule],
   providers: [
     ...sqliteDatabaseProviders,
     ...threadProviders,

--- a/cortex-js/src/infrastructure/database/sqlite-database.providers.ts
+++ b/cortex-js/src/infrastructure/database/sqlite-database.providers.ts
@@ -1,12 +1,15 @@
+import { FileManagerService } from '@/file-manager/file-manager.service';
 import { databaseFile } from 'constant';
-import { resolve } from 'path';
+import { join } from 'path';
 import { DataSource } from 'typeorm';
 
 export const sqliteDatabaseProviders = [
   {
     provide: 'DATA_SOURCE',
-    useFactory: async () => {
-      const sqlitePath = resolve(__dirname, `../../../${databaseFile}`);
+    inject: [FileManagerService],
+    useFactory: async (fileManagerService: FileManagerService) => {
+      const dataFolderPath = await fileManagerService.getDataFolderPath();
+      const sqlitePath = join(dataFolderPath, databaseFile);
       const dataSource = new DataSource({
         type: 'sqlite',
         database: sqlitePath,

--- a/cortex-js/src/infrastructure/providers/cortex/cortex.module.ts
+++ b/cortex-js/src/infrastructure/providers/cortex/cortex.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import CortexProvider from './cortex.provider';
 import { HttpModule } from '@nestjs/axios';
+import { FileManagerModule } from '@/file-manager/file-manager.module';
 
 @Module({
-  imports: [HttpModule],
+  imports: [HttpModule, FileManagerModule],
   providers: [
     {
       provide: 'CORTEX_PROVIDER',

--- a/cortex-js/src/main.ts
+++ b/cortex-js/src/main.ts
@@ -4,6 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { defaultCortexJsHost, defaultCortexJsPort } from 'constant';
 import { SeedService } from './usecases/seed/seed.service';
+import { FileManagerService } from './file-manager/file-manager.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -12,6 +13,9 @@ async function bootstrap() {
   });
   const seedService = app.get(SeedService);
   await seedService.seed();
+
+  const fileService = app.get(FileManagerService);
+  await fileService.getConfig();
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/cortex-js/src/usecases/cortex/cortex.module.ts
+++ b/cortex-js/src/usecases/cortex/cortex.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { CortexUsecases } from './cortex.usecases';
 import { CortexController } from '@/infrastructure/controllers/cortex.controller';
 import { HttpModule } from '@nestjs/axios';
+import { FileManagerModule } from '@/file-manager/file-manager.module';
 
 @Module({
-  imports: [HttpModule],
+  imports: [HttpModule, FileManagerModule],
   providers: [CortexUsecases],
   controllers: [CortexController],
   exports: [CortexUsecases],

--- a/cortex-js/src/usecases/models/models.module.ts
+++ b/cortex-js/src/usecases/models/models.module.ts
@@ -5,9 +5,16 @@ import { DatabaseModule } from '@/infrastructure/database/database.module';
 import { CortexModule } from '@/usecases/cortex/cortex.module';
 import { ExtensionModule } from '@/infrastructure/repositories/extensions/extension.module';
 import { HttpModule } from '@nestjs/axios';
+import { FileManagerModule } from '@/file-manager/file-manager.module';
 
 @Module({
-  imports: [DatabaseModule, CortexModule, ExtensionModule, HttpModule],
+  imports: [
+    DatabaseModule,
+    CortexModule,
+    ExtensionModule,
+    HttpModule,
+    FileManagerModule,
+  ],
   controllers: [ModelsController],
   providers: [ModelsUsecases],
   exports: [ModelsUsecases],


### PR DESCRIPTION
## Describe Your Changes

- Store cortex data in a separate directory so user can freely upgrade their cortex without worry losing their data.
- Store cortex setting under `~/.cortexrc`. Consider removing suffix `rc` because it seems abit weird.

## Screenshots
<img width="446" alt="Screenshot 2024-05-27 at 17 02 03" src="https://github.com/janhq/cortex/assets/10397206/6f2e190e-e8cf-4995-9218-c9035e7cfa1d">
<img width="476" alt="Screenshot 2024-05-27 at 17 05 55" src="https://github.com/janhq/cortex/assets/10397206/863f4a0d-7969-4f8f-9a6c-dff93e90ae8f">


## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed