### PR TITLE
feat: ps command support

### DIFF
--- a/cortex-js/src/command.module.ts
+++ b/cortex-js/src/command.module.ts
@@ -24,6 +24,7 @@ import { AssistantsModule } from './usecases/assistants/assistants.module';
 import { CliUsecasesModule } from './infrastructure/commanders/usecases/cli.usecases.module';
 import { MessagesModule } from './usecases/messages/messages.module';
 import { FileManagerModule } from './file-manager/file-manager.module';
+import { PSCommand } from './infrastructure/commanders/ps.command';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { FileManagerModule } from './file-manager/file-manager.module';
     ServeCommand,
     ChatCommand,
     InitCommand,
+    PSCommand,
 
     // Questions
     InitRunModeQuestions,

--- a/cortex-js/src/command.module.ts
+++ b/cortex-js/src/command.module.ts
@@ -25,6 +25,7 @@ import { CliUsecasesModule } from './infrastructure/commanders/usecases/cli.usec
 import { MessagesModule } from './usecases/messages/messages.module';
 import { FileManagerModule } from './file-manager/file-manager.module';
 import { PSCommand } from './infrastructure/commanders/ps.command';
+import { KillCommand } from './infrastructure/commanders/kill.command';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { PSCommand } from './infrastructure/commanders/ps.command';
     ChatCommand,
     InitCommand,
     PSCommand,
+    KillCommand,
 
     // Questions
     InitRunModeQuestions,

--- a/cortex-js/src/infrastructure/commanders/cortex-command.commander.ts
+++ b/cortex-js/src/infrastructure/commanders/cortex-command.commander.ts
@@ -5,6 +5,7 @@ import { ModelsCommand } from './models.command';
 import { InitCommand } from './init.command';
 import { RunCommand } from './shortcuts/run.command';
 import { ModelPullCommand } from './models/model-pull.command';
+import { PSCommand } from './ps.command';
 
 @RootCommand({
   subCommands: [
@@ -14,6 +15,7 @@ import { ModelPullCommand } from './models/model-pull.command';
     InitCommand,
     RunCommand,
     ModelPullCommand,
+    PSCommand,
   ],
   description: 'Cortex CLI',
 })

--- a/cortex-js/src/infrastructure/commanders/cortex-command.commander.ts
+++ b/cortex-js/src/infrastructure/commanders/cortex-command.commander.ts
@@ -6,6 +6,7 @@ import { InitCommand } from './init.command';
 import { RunCommand } from './shortcuts/run.command';
 import { ModelPullCommand } from './models/model-pull.command';
 import { PSCommand } from './ps.command';
+import { KillCommand } from './kill.command';
 
 @RootCommand({
   subCommands: [
@@ -16,6 +17,7 @@ import { PSCommand } from './ps.command';
     RunCommand,
     ModelPullCommand,
     PSCommand,
+    KillCommand,
   ],
   description: 'Cortex CLI',
 })

--- a/cortex-js/src/infrastructure/commanders/kill.command.ts
+++ b/cortex-js/src/infrastructure/commanders/kill.command.ts
@@ -1,0 +1,15 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { CortexUsecases } from '@/usecases/cortex/cortex.usecases';
+
+@SubCommand({
+  name: 'kill',
+  description: 'Kill running cortex processes',
+})
+export class KillCommand extends CommandRunner {
+  constructor(private readonly usecases: CortexUsecases) {
+    super();
+  }
+  async run(): Promise<void> {
+    this.usecases.stopCortex().then(console.log);
+  }
+}

--- a/cortex-js/src/infrastructure/commanders/models/model-start.command.ts
+++ b/cortex-js/src/infrastructure/commanders/models/model-start.command.ts
@@ -1,8 +1,11 @@
-import { CommandRunner, SubCommand } from 'nest-commander';
+import { CommandRunner, SubCommand, Option } from 'nest-commander';
 import { exit } from 'node:process';
 import { ModelsCliUsecases } from '../usecases/models.cli.usecases';
 import { CortexUsecases } from '@/usecases/cortex/cortex.usecases';
 
+type ModelStartOptions = {
+  attach: boolean;
+};
 @SubCommand({ name: 'start', description: 'Start a model by ID.' })
 export class ModelStartCommand extends CommandRunner {
   constructor(
@@ -12,13 +15,26 @@ export class ModelStartCommand extends CommandRunner {
     super();
   }
 
-  async run(input: string[]): Promise<void> {
+  async run(input: string[], options: ModelStartOptions): Promise<void> {
     if (input.length === 0) {
       console.error('Model ID is required');
       exit(1);
     }
 
-    await this.cortexUsecases.startCortex();
-    await this.modelsCliUsecases.startModel(input[0]);
+    await this.cortexUsecases
+      .startCortex(options.attach)
+      .then(() => this.modelsCliUsecases.startModel(input[0]))
+      .then(console.log)
+      .then(() => !options.attach && process.exit(0));
+  }
+
+  @Option({
+    flags: '-a, --attach',
+    description: 'Attach to interactive chat session',
+    defaultValue: false,
+    name: 'attach',
+  })
+  parseAttach() {
+    return true;
   }
 }

--- a/cortex-js/src/infrastructure/commanders/models/model-stop.command.ts
+++ b/cortex-js/src/infrastructure/commanders/models/model-stop.command.ts
@@ -18,7 +18,8 @@ export class ModelStopCommand extends CommandRunner {
       exit(1);
     }
 
-    await this.modelsCliUsecases.stopModel(input[0]);
-    await this.cortexUsecases.stopCortex();
+    await this.modelsCliUsecases
+      .stopModel(input[0])
+      .then(() => this.cortexUsecases.stopCortex());
   }
 }

--- a/cortex-js/src/infrastructure/commanders/models/model-stop.command.ts
+++ b/cortex-js/src/infrastructure/commanders/models/model-stop.command.ts
@@ -20,6 +20,7 @@ export class ModelStopCommand extends CommandRunner {
 
     await this.modelsCliUsecases
       .stopModel(input[0])
-      .then(() => this.cortexUsecases.stopCortex());
+      .then(() => this.cortexUsecases.stopCortex())
+      .then(console.log);
   }
 }

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -10,6 +10,17 @@ export class PSCommand extends CommandRunner {
     super();
   }
   async run(): Promise<void> {
-    this.usecases.getModels();
+    this.usecases.getModels().then((data) => {
+      console.table(
+        data.map((e) => {
+          return {
+            modelId: e.id,
+            engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
+            status: 'running',
+            created: e.created ?? new Date(),
+          };
+        }),
+      );
+    });
   }
 }

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -11,6 +11,10 @@ export class PSCommand extends CommandRunner {
   }
   async run(): Promise<void> {
     this.usecases.getModels().then((data) => {
+      if (data.length === 0) {
+        console.log('No running models');
+        return;
+      }
       console.table(
         data.map((e) => {
           return {

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -1,0 +1,15 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { PSCliUsecases } from './usecases/ps.cli.usecases';
+
+@SubCommand({
+  name: 'ps',
+  description: 'Show running models and their status',
+})
+export class PSCommand extends CommandRunner {
+  constructor(private readonly usecases: PSCliUsecases) {
+    super();
+  }
+  async run(): Promise<void> {
+    this.usecases.getModels();
+  }
+}

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -10,21 +10,26 @@ export class PSCommand extends CommandRunner {
     super();
   }
   async run(): Promise<void> {
-    this.usecases.getModels().then((data) => {
-      if (data.length === 0) {
+    this.usecases
+      .getModels()
+      .then((data) => {
+        if (data.length === 0) {
+          console.log('No running models');
+          return;
+        }
+        console.table(
+          data.map((e) => {
+            return {
+              modelId: e.id,
+              engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
+              status: 'running',
+              created: e.created ?? new Date(),
+            };
+          }),
+        );
+      })
+      .catch(() => {
         console.log('No running models');
-        return;
-      }
-      console.table(
-        data.map((e) => {
-          return {
-            modelId: e.id,
-            engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
-            status: 'running',
-            created: e.created ?? new Date(),
-          };
-        }),
-      );
-    });
+      });
   }
 }

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -10,28 +10,6 @@ export class PSCommand extends CommandRunner {
     super();
   }
   async run(): Promise<void> {
-    this.usecases
-      .getModels()
-      .then((data) => {
-        if (data.length === 0) {
-          console.log('No running models');
-          return;
-        }
-        console.table(
-          data.map((e) => {
-            return {
-              modelId: e.id,
-              engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
-              status: 'running',
-              startTime: e.start_time ?? new Date(),
-              ram: e.ram ?? '-',
-              vram: e.vram ?? '-',
-            };
-          }),
-        );
-      })
-      .catch(() => {
-        console.log('No running models');
-      });
+    return this.usecases.getModels().then(console.table);
   }
 }

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -23,7 +23,9 @@ export class PSCommand extends CommandRunner {
               modelId: e.id,
               engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
               status: 'running',
-              created: e.created ?? new Date(),
+              startTime: e.start_time ?? new Date(),
+              ram: e.ram ?? '-',
+              vram: e.vram ?? '-',
             };
           }),
         );

--- a/cortex-js/src/infrastructure/commanders/shortcuts/run.command.ts
+++ b/cortex-js/src/infrastructure/commanders/shortcuts/run.command.ts
@@ -30,9 +30,9 @@ export class RunCommand extends CommandRunner {
     const modelId = input[0];
 
     await this.cortexUsecases.startCortex(
+      false,
       defaultCortexCppHost,
       defaultCortexCppPort,
-      false,
     );
     await this.modelsUsecases.startModel(modelId);
     await this.chatCliUsecases.chat(modelId, option?.threadId);

--- a/cortex-js/src/infrastructure/commanders/usecases/cli.usecases.module.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/cli.usecases.module.ts
@@ -10,6 +10,7 @@ import { ThreadsModule } from '@/usecases/threads/threads.module';
 import { AssistantsModule } from '@/usecases/assistants/assistants.module';
 import { MessagesModule } from '@/usecases/messages/messages.module';
 import { FileManagerModule } from '@/file-manager/file-manager.module';
+import { PSCliUsecases } from './ps.cli.usecases';
 
 @Module({
   imports: [
@@ -22,7 +23,12 @@ import { FileManagerModule } from '@/file-manager/file-manager.module';
     MessagesModule,
     FileManagerModule,
   ],
-  providers: [InitCliUsecases, ModelsCliUsecases, ChatCliUsecases],
-  exports: [InitCliUsecases, ModelsCliUsecases, ChatCliUsecases],
+  providers: [
+    InitCliUsecases,
+    ModelsCliUsecases,
+    ChatCliUsecases,
+    PSCliUsecases,
+  ],
+  exports: [InitCliUsecases, ModelsCliUsecases, ChatCliUsecases, PSCliUsecases],
 })
 export class CliUsecasesModule {}

--- a/cortex-js/src/infrastructure/commanders/usecases/models.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/models.cli.usecases.ts
@@ -78,8 +78,9 @@ export class ModelsCliUsecases {
    * @param modelId
    */
   async stopModel(modelId: string): Promise<void> {
-    await this.getModelOrStop(modelId);
-    await this.modelsUsecases.stopModel(modelId);
+    return this.getModelOrStop(modelId)
+      .then(() => this.modelsUsecases.stopModel(modelId))
+      .then();
   }
 
   /**

--- a/cortex-js/src/infrastructure/commanders/usecases/models.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/models.cli.usecases.ts
@@ -24,6 +24,7 @@ import {
 import { ModelTokenizer } from '../types/model-tokenizer.interface';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
+import { StartModelSuccessDto } from '@/infrastructure/dtos/models/start-model-success.dto';
 
 const AllQuantizations = [
   'Q3_K_S',
@@ -61,9 +62,15 @@ export class ModelsCliUsecases {
    * Start a model by ID
    * @param modelId
    */
-  async startModel(modelId: string): Promise<void> {
-    await this.getModelOrStop(modelId);
-    await this.modelsUsecases.startModel(modelId);
+  async startModel(modelId: string): Promise<StartModelSuccessDto> {
+    return this.getModelOrStop(modelId)
+      .then(() => this.modelsUsecases.startModel(modelId))
+      .catch(() => {
+        return {
+          modelId: modelId,
+          message: 'Model not found',
+        };
+      });
   }
 
   /**

--- a/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
@@ -5,7 +5,7 @@ interface ModelStat {
   id: number;
   modelId: string;
   engine?: string;
-  created?: string;
+  start_time?: string;
   status: string;
   vram?: string;
   ram?: string;

--- a/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
@@ -26,18 +26,20 @@ export class PSCliUsecases {
     port: number = defaultCortexCppPort,
   ): Promise<ModelStat[]> {
     return new Promise<ModelStat[]>((resolve, reject) =>
-      fetch(`http://${host}:${port}/inferences/server/models`).then((res) => {
-        if (res.ok) {
-          res
-            .json()
-            .then(({ data }: ModelStatResponse) => {
-              if (data && Array.isArray(data) && data.length > 0) {
-                resolve(data);
-              } else reject();
-            })
-            .catch(reject);
-        } else reject();
-      }),
+      fetch(`http://${host}:${port}/inferences/server/models`)
+        .then((res) => {
+          if (res.ok) {
+            res
+              .json()
+              .then(({ data }: ModelStatResponse) => {
+                if (data && Array.isArray(data) && data.length > 0) {
+                  resolve(data);
+                } else reject();
+              })
+              .catch(reject);
+          } else reject();
+        })
+        .catch(reject),
     ).catch(() => []);
   }
 }

--- a/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { defaultCortexCppHost, defaultCortexCppPort } from 'constant';
+
+interface ModelStat {
+  id: number;
+  modelId: string;
+  engine?: string;
+  created?: string;
+  status: string;
+  vram?: string;
+  ram?: string;
+}
+interface ModelStatResponse {
+  object: string;
+  data: ModelStat[];
+}
+@Injectable()
+export class PSCliUsecases {
+  /**
+   * Get models running in the Cortex C++ server
+   * @param host Cortex host address
+   * @param port Cortex port address
+   */
+  async getModels(
+    host: string = defaultCortexCppHost,
+    port: number = defaultCortexCppPort,
+  ): Promise<void> {
+    new Promise<void>((resolve, reject) =>
+      fetch(`http://${host}:${port}/inferences/server/models`).then((res) => {
+        if (res.ok) {
+          res
+            .json()
+            .then(({ data }: ModelStatResponse) => {
+              if (data && Array.isArray(data) && data.length > 0) {
+                console.table(
+                  data.map((e) => {
+                    return {
+                      modelId: e.id,
+                      engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
+                      status: 'running',
+                      created: e.created ?? new Date(),
+                    };
+                  }),
+                );
+                resolve();
+              } else reject();
+            })
+            .catch(reject);
+        } else reject();
+      }),
+    ).catch(() => console.log('No models running.'));
+  }
+}

--- a/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
@@ -24,30 +24,20 @@ export class PSCliUsecases {
   async getModels(
     host: string = defaultCortexCppHost,
     port: number = defaultCortexCppPort,
-  ): Promise<void> {
-    new Promise<void>((resolve, reject) =>
+  ): Promise<ModelStat[]> {
+    return new Promise<ModelStat[]>((resolve, reject) =>
       fetch(`http://${host}:${port}/inferences/server/models`).then((res) => {
         if (res.ok) {
           res
             .json()
             .then(({ data }: ModelStatResponse) => {
               if (data && Array.isArray(data) && data.length > 0) {
-                console.table(
-                  data.map((e) => {
-                    return {
-                      modelId: e.id,
-                      engine: e.engine ?? 'llama.cpp', // TODO: get engine from model when it's ready
-                      status: 'running',
-                      created: e.created ?? new Date(),
-                    };
-                  }),
-                );
-                resolve();
+                resolve(data);
               } else reject();
             })
             .catch(reject);
         } else reject();
       }),
-    ).catch(() => console.log('No models running.'));
+    ).catch(() => []);
   }
 }

--- a/cortex-js/src/infrastructure/controllers/cortex.controller.ts
+++ b/cortex-js/src/infrastructure/controllers/cortex.controller.ts
@@ -22,6 +22,7 @@ export class CortexController {
   @Post('start')
   startCortex(@Body() startCortexDto: StartCortexDto) {
     return this.cortexUsecases.startCortex(
+      false,
       startCortexDto.host,
       startCortexDto.port,
     );

--- a/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
+++ b/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
@@ -82,13 +82,13 @@ export default class CortexProvider extends OAIEngineExtension {
 
     return firstValueFrom(
       this.httpService.post(this.loadModelUrl, modelSettings),
-    ).then(() => {}); // pipe error or void instead of throwing
+    ).then();
   }
 
   override async unloadModel(modelId: string): Promise<void> {
     return firstValueFrom(
       this.httpService.post(this.unloadModelUrl, { model: modelId }),
-    ).then(() => {}); // pipe error or void instead of throwing
+    ).then(); // pipe error or void instead of throwing
   }
 
   private readonly promptTemplateConverter = (

--- a/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
+++ b/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
@@ -80,15 +80,15 @@ export default class CortexProvider extends OAIEngineExtension {
       modelSettings.ai_prompt = prompt.ai_prompt;
     }
 
-    await firstValueFrom(
+    return firstValueFrom(
       this.httpService.post(this.loadModelUrl, modelSettings),
-    );
+    ).then(() => {}); // pipe error or void instead of throwing
   }
 
   override async unloadModel(modelId: string): Promise<void> {
-    await firstValueFrom(
+    return firstValueFrom(
       this.httpService.post(this.unloadModelUrl, { model: modelId }),
-    );
+    ).then(() => {}); // pipe error or void instead of throwing
   }
 
   private readonly promptTemplateConverter = (

--- a/cortex-js/src/usecases/cortex/cortex.usecases.ts
+++ b/cortex-js/src/usecases/cortex/cortex.usecases.ts
@@ -71,8 +71,8 @@ export class CortexUsecases {
   }
 
   async stopCortex(
-    host?: string,
-    port?: number,
+    host: string = defaultCortexCppHost,
+    port: number = defaultCortexCppPort,
   ): Promise<CortexOperationSuccessfullyDto> {
     try {
       await firstValueFrom(

--- a/cortex-js/src/usecases/models/models.usecases.ts
+++ b/cortex-js/src/usecases/models/models.usecases.ts
@@ -152,8 +152,7 @@ export class ModelsUsecases {
           modelId: modelId,
         };
       })
-      .catch((err) => {
-        console.error(err);
+      .catch(() => {
         return {
           message: 'Model failed to load',
           modelId: modelId,
@@ -183,8 +182,7 @@ export class ModelsUsecases {
           modelId,
         };
       })
-      .catch((err) => {
-        console.error(err);
+      .catch(() => {
         return {
           message: 'Failed to stop model',
           modelId,

--- a/cortex-js/src/usecases/models/models.usecases.ts
+++ b/cortex-js/src/usecases/models/models.usecases.ts
@@ -26,6 +26,7 @@ import { ModelSettingParamsDto } from '@/infrastructure/dtos/models/model-settin
 import { normalizeModelId } from '@/infrastructure/commanders/utils/normalize-model-id';
 import { firstValueFrom } from 'rxjs';
 import { FileManagerService } from '@/file-manager/file-manager.service';
+import { AxiosError } from 'axios';
 
 @Injectable()
 export class ModelsUsecases {
@@ -152,7 +153,13 @@ export class ModelsUsecases {
           modelId: modelId,
         };
       })
-      .catch(() => {
+      .catch((e) => {
+        if (e.code === AxiosError.ERR_BAD_REQUEST) {
+          return {
+            message: 'Model already loaded',
+            modelId: modelId,
+          };
+        }
         return {
           message: 'Model failed to load',
           modelId: modelId,


### PR DESCRIPTION
## Describe Your Changes

- Add `cortex ps` command support that fetches all models loaded from the Cortex-CPP process.

<img width="1010" alt="Screenshot 2024-05-29 at 20 39 14" src="https://github.com/janhq/cortex/assets/133622055/40417479-3b2e-4455-bf70-463801efe3b1">


- Added `cortex models start` `-a` argument to support attach / detach option (detach by default)

- Fixed `cortex models start | stop` error outputs

- Added `cortex kill` - it's to kill any running cortex processes

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed