### PR TITLE
feat: cortex post-install script - init silently on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,7 @@ To install Cortex CLI, follow the steps below:
 npm i -g @janhq/cortex
 ```
 
-2. Initialize a compatible engine:
-``` bash
-cortex init
-```
-
-3. Download a GGUF model from Hugging Face:
+2. Download a GGUF model from Hugging Face:
 ``` bash
 # Pull a model most compatible with your hardware
 cortex pull llama3
@@ -84,12 +79,12 @@ cortex pull llama3:7b
 # Pull a model with the HuggingFace `model_id`
 cortex pull microsoft/Phi-3-mini-4k-instruct-gguf
 ```
-4. Load the model:
+3. Load the model:
 ``` bash
 cortex models start llama3:7b
 ```
 
-5. Start chatting with the model:
+4. Start chatting with the model:
 ``` bash
 cortex chat tell me a joke
 ```

--- a/cortex-js/README.md
+++ b/cortex-js/README.md
@@ -68,12 +68,7 @@ To install Cortex CLI, follow the steps below:
 npm i -g @janhq/cortex
 ```
 
-2. Initialize a compatible engine:
-``` bash
-cortex init
-```
-
-3. Download a GGUF model from Hugging Face:
+2. Download a GGUF model from Hugging Face:
 ``` bash
 # Pull a model most compatible with your hardware
 cortex pull llama3
@@ -84,12 +79,12 @@ cortex pull llama3:7b
 # Pull a model with the HuggingFace `model_id`
 cortex pull microsoft/Phi-3-mini-4k-instruct-gguf
 ```
-4. Load the model:
+3. Load the model:
 ``` bash
 cortex models start llama3:7b
 ```
 
-5. Start chatting with the model:
+4. Start chatting with the model:
 ``` bash
 cortex chat tell me a joke
 ```

--- a/cortex-js/package.json
+++ b/cortex-js/package.json
@@ -26,7 +26,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "typeorm-ts-node-esm",
-    "build:dev": "npx nest build && chmod +x ./dist/src/command.js && npm link"
+    "build:dev": "npx nest build && chmod +x ./dist/src/command.js && npm link",
+    "postinstall": "cortex init -s"
   },
   "dependencies": {
     "@huggingface/gguf": "^0.1.5",

--- a/cortex-js/src/infrastructure/commanders/types/init-options.interface.ts
+++ b/cortex-js/src/infrastructure/commanders/types/init-options.interface.ts
@@ -4,4 +4,5 @@ export interface InitOptions {
   instructions?: 'AVX' | 'AVX2' | 'AVX512' | undefined;
   cudaVersion?: '11' | '12';
   installCuda?: 'Yes' | string;
+  silent?: boolean;
 }


### PR DESCRIPTION
## Describe Your Changes
- This PR adds a post-install script that downloads the corresponding Cortex dependencies based on the user's hardware specs during installation. So, after installing Cortex from the npm repo, there is no need to run `cortex init` to get started.

- Removed cortex init step from README

Support: 
- Nvidia GPUs (ROCm is in progress)
- CPU with AVX-512, AVX2, AVX
- Apple Silicon

<img width="467" alt="image" src="https://github.com/janhq/cortex/assets/133622055/1f67e576-d5b9-4d7c-a326-03a11b697686">


## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed