### PR TITLE
chore: cortex.llamacpp to version 0.1.17

### DIFF
--- a/.github/workflows/cortex-cpp-build.yml
+++ b/.github/workflows/cortex-cpp-build.yml
@@ -97,25 +97,25 @@ jobs:
 
           - os: "windows"
             name: "amd64-avx2"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_AVX2=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
 
           - os: "windows"
             name: "amd64-avx"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_AVX2=OFF -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
 
           - os: "windows"
             name: "amd64-avx512"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_AVX512=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
 
           - os: "windows"
             name: "amd64-vulkan"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_VULKAN=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
 

--- a/.github/workflows/cortex-cpp-quality-gate.yml
+++ b/.github/workflows/cortex-cpp-quality-gate.yml
@@ -80,28 +80,28 @@ jobs:
 
           - os: "windows"
             name: "amd64-avx2"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_AVX2=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: true
             run-python-e2e: true
 
           - os: "windows"
             name: "amd64-avx"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_AVX2=OFF -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             run-python-e2e: false
 
           - os: "windows"
             name: "amd64-avx512"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_AVX512=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             run-python-e2e: false
 
           - os: "windows"
             name: "amd64-vulkan"
-            runs-on: "windows-latest"
+            runs-on: "windows-cuda-12-0"
             cmake-flags: "-DLLAMA_VULKAN=ON -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=RELEASE"
             run-e2e: false
             run-python-e2e: false

--- a/cortex-cpp/engines/cortex.llamacpp/engine.cmake
+++ b/cortex-cpp/engines/cortex.llamacpp/engine.cmake
@@ -1,5 +1,5 @@
 # cortex.llamacpp release version
-set(VERSION 0.1.15)
+set(VERSION 0.1.17)
 set(ENGINE_VERSION v${VERSION})
 add_compile_definitions(CORTEX_LLAMACPP_VERSION="${VERSION}")
 


### PR DESCRIPTION
## Describe Your Changes
- Change Windows CI runner to `windows-cuda-12-0` because `windows-latest` makes our server crashes after some `poll` and `select` calls.
- https://github.com/janhq/cortex.llamacpp/releases/tag/v0.1.17

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed