### PR TITLE
chore: comment out hacky latest download state update that break the downloading flow

### DIFF
--- a/cortex-js/src/download-manager/download-manager.service.ts
+++ b/cortex-js/src/download-manager/download-manager.service.ts
@@ -21,9 +21,9 @@ export class DownloadManagerService {
     private readonly eventEmitter: EventEmitter2,
   ) {
     // start emitting download state each 500ms
-    setInterval(() => {
-      this.eventEmitter.emit('download.event', this.allDownloadStates);
-    }, 500);
+    // setInterval(() => {
+    //   this.eventEmitter.emit('download.event', this.allDownloadStates);
+    // }, 500);
   }
 
   async abortDownload(downloadId: string) {


### PR DESCRIPTION
## Describe Your Changes

Since #686, all of the cli download operations stopped working. This is to temporary comment out the broken code block til it's fixed.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed