### PR TITLE
feat: add cortex serve detach option - add health check and stop api endpoints

### DIFF
--- a/cortex-js/src/app.module.ts
+++ b/cortex-js/src/app.module.ts
@@ -17,6 +17,14 @@ import { AppLoggerMiddleware } from './infrastructure/middlewares/app.logger.mid
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { DownloadManagerModule } from './download-manager/download-manager.module';
 import { EventsController } from './infrastructure/controllers/events.controller';
+import { AppController } from './infrastructure/controllers/app.controller';
+import { AssistantsController } from './infrastructure/controllers/assistants.controller';
+import { ChatController } from './infrastructure/controllers/chat.controller';
+import { EmbeddingsController } from './infrastructure/controllers/embeddings.controller';
+import { ModelsController } from './infrastructure/controllers/models.controller';
+import { ThreadsController } from './infrastructure/controllers/threads.controller';
+import { StatusController } from './infrastructure/controllers/status.controller';
+import { ProcessController } from './infrastructure/controllers/process.controller';
 
 @Module({
   imports: [
@@ -40,7 +48,17 @@ import { EventsController } from './infrastructure/controllers/events.controller
     ModelRepositoryModule,
     DownloadManagerModule,
   ],
-  controllers: [EventsController],
+  controllers: [
+    AppController,
+    AssistantsController,
+    ChatController,
+    EmbeddingsController,
+    ModelsController,
+    ThreadsController,
+    StatusController,
+    ProcessController,
+    EventsController,
+  ],
   providers: [SeedService],
 })
 export class AppModule implements NestModule {

--- a/cortex-js/src/infrastructure/commanders/ps.command.ts
+++ b/cortex-js/src/infrastructure/commanders/ps.command.ts
@@ -10,6 +10,12 @@ export class PSCommand extends CommandRunner {
     super();
   }
   async run(): Promise<void> {
-    return this.usecases.getModels().then(console.table);
+    return this.usecases
+      .getModels()
+      .then(console.table)
+      .then(() => this.usecases.isAPIServerOnline())
+      .then((isOnline) => {
+        if (isOnline) console.log('API server is online');
+      });
   }
 }

--- a/cortex-js/src/infrastructure/commanders/serve.command.ts
+++ b/cortex-js/src/infrastructure/commanders/serve.command.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import {
+  CORTEX_JS_STOP_API_SERVER_URL,
   defaultCortexJsHost,
   defaultCortexJsPort,
 } from '@/infrastructure/constants/cortex';
@@ -9,6 +10,7 @@ import { join } from 'path';
 type ServeOptions = {
   host?: string;
   port?: number;
+  attach: boolean;
 };
 
 @SubCommand({
@@ -20,7 +22,25 @@ export class ServeCommand extends CommandRunner {
     const host = options?.host || defaultCortexJsHost;
     const port = options?.port || defaultCortexJsPort;
 
-    spawn(
+    if (_input[0] === 'stop') {
+      return this.stopServer().then(() => console.log('API server stopped'));
+    } else {
+      return this.startServer(host, port, options);
+    }
+  }
+
+  private async stopServer() {
+    return fetch(CORTEX_JS_STOP_API_SERVER_URL(), {
+      method: 'DELETE',
+    }).catch(() => {});
+  }
+
+  private async startServer(
+    host: string,
+    port: number,
+    options: ServeOptions = { attach: true },
+  ) {
+    const serveProcess = spawn(
       'node',
       process.env.TEST
         ? [join(__dirname, '../../../dist/src/main.js')]
@@ -32,10 +52,14 @@ export class ServeCommand extends CommandRunner {
           CORTEX_JS_PORT: port.toString(),
           NODE_ENV: 'production',
         },
-        stdio: 'inherit',
-        detached: false,
+        stdio: options?.attach ? 'inherit' : 'ignore',
+        detached: true,
       },
     );
+    if (!options?.attach) {
+      serveProcess.unref();
+      console.log('Started server at http://%s:%d', host, port);
+    }
   }
 
   @Option({
@@ -52,5 +76,15 @@ export class ServeCommand extends CommandRunner {
   })
   parsePort(value: string) {
     return parseInt(value, 10);
+  }
+
+  @Option({
+    flags: '-a, --attach',
+    description: 'Attach to interactive chat session',
+    defaultValue: false,
+    name: 'attach',
+  })
+  parseAttach() {
+    return true;
   }
 }

--- a/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/ps.cli.usecases.ts
@@ -1,8 +1,11 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import {
   CORTEX_CPP_MODELS_URL,
+  CORTEX_JS_HEALTH_URL,
   defaultCortexCppHost,
   defaultCortexCppPort,
+  defaultCortexJsHost,
+  defaultCortexJsPort,
 } from '@/infrastructure/constants/cortex';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
@@ -54,6 +57,23 @@ export class PSCliUsecases {
         })
         .catch(reject),
     ).catch(() => []);
+  }
+
+  /**
+   * Check if the Cortex API server is online
+   * @param host Cortex host address
+   * @param port Cortex port address
+   * @returns
+   */
+  async isAPIServerOnline(
+    host: string = defaultCortexJsHost,
+    port: number = defaultCortexJsPort,
+  ): Promise<boolean> {
+    return firstValueFrom(
+      this.httpService.get(CORTEX_JS_HEALTH_URL(host, port)),
+    )
+      .then((res) => res.status === HttpStatus.OK)
+      .catch(() => false);
   }
 
   private formatDuration(milliseconds: number): string {

--- a/cortex-js/src/infrastructure/constants/cortex.ts
+++ b/cortex-js/src/infrastructure/constants/cortex.ts
@@ -28,6 +28,16 @@ export const CORTEX_CPP_MODELS_URL = (
   port: number = defaultCortexCppPort,
 ) => `http://${host}:${port}/inferences/server/models`;
 
+export const CORTEX_JS_HEALTH_URL = (
+  host: string = defaultCortexJsHost,
+  port: number = defaultCortexJsPort,
+) => `http://${host}:${port}/health`;
+
+export const CORTEX_JS_STOP_API_SERVER_URL = (
+  host: string = defaultCortexJsHost,
+  port: number = defaultCortexJsPort,
+) => `http://${host}:${port}/process`;
+
 // INITIALIZATION
 export const CORTEX_RELEASES_URL =
   'https://api.github.com/repos/janhq/cortex/releases';

--- a/cortex-js/src/infrastructure/controllers/process.controller.ts
+++ b/cortex-js/src/infrastructure/controllers/process.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Delete } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Processes')
+@Controller('process')
+export class ProcessController {
+  constructor() {}
+
+  @ApiOperation({
+    summary: 'Terminate service',
+    description: 'Terminate service endpoint',
+  })
+  @Delete()
+  async delete() {
+    process.exit(0);
+  }
+}

--- a/cortex-js/src/infrastructure/controllers/status.controller.ts
+++ b/cortex-js/src/infrastructure/controllers/status.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, HttpCode, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('Status')
+@Controller('health')
+export class StatusController {
+  constructor() {}
+
+  @ApiOperation({
+    summary: 'Health check',
+    description: 'Health check endpoint.',
+  })
+  @HttpCode(200)
+  @ApiResponse({
+    status: 200,
+    description: 'Ok',
+  })
+  @Get()
+  async get() {
+    return 'OK';
+  }
+}

--- a/cortex-js/src/main.ts
+++ b/cortex-js/src/main.ts
@@ -70,7 +70,7 @@ async function bootstrap() {
   const port = process.env.CORTEX_JS_PORT || defaultCortexJsPort;
 
   await app.listen(port, host);
-  console.log(`Server running on http://${host}:${port}`);
+  console.log(`Started server at http://${host}:${port}`);
 }
 
 const buildSwagger = (app: INestApplication<any>) => {

--- a/cortex-js/src/usecases/assistants/assistants.module.ts
+++ b/cortex-js/src/usecases/assistants/assistants.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
-import { AssistantsController } from '@/infrastructure/controllers/assistants.controller';
 import { AssistantsUsecases } from './assistants.usecases';
 import { DatabaseModule } from '@/infrastructure/database/database.module';
 
 @Module({
   imports: [DatabaseModule],
-  controllers: [AssistantsController],
+  controllers: [],
   providers: [AssistantsUsecases],
   exports: [AssistantsUsecases],
 })

--- a/cortex-js/src/usecases/chat/chat.module.ts
+++ b/cortex-js/src/usecases/chat/chat.module.ts
@@ -1,15 +1,13 @@
 import { Module } from '@nestjs/common';
-import { ChatController } from '@/infrastructure/controllers/chat.controller';
 import { ChatUsecases } from './chat.usecases';
 import { DatabaseModule } from '@/infrastructure/database/database.module';
 import { ExtensionModule } from '@/infrastructure/repositories/extensions/extension.module';
 import { ModelRepositoryModule } from '@/infrastructure/repositories/models/model.module';
 import { HttpModule } from '@nestjs/axios';
-import { EmbeddingsController } from '@/infrastructure/controllers/embeddings.controller';
 
 @Module({
   imports: [DatabaseModule, ExtensionModule, ModelRepositoryModule, HttpModule],
-  controllers: [ChatController, EmbeddingsController],
+  controllers: [],
   providers: [ChatUsecases],
   exports: [ChatUsecases],
 })

--- a/cortex-js/src/usecases/models/models.module.ts
+++ b/cortex-js/src/usecases/models/models.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { ModelsUsecases } from './models.usecases';
-import { ModelsController } from '@/infrastructure/controllers/models.controller';
 import { DatabaseModule } from '@/infrastructure/database/database.module';
 import { CortexModule } from '@/usecases/cortex/cortex.module';
 import { ExtensionModule } from '@/infrastructure/repositories/extensions/extension.module';
@@ -19,7 +18,7 @@ import { DownloadManagerModule } from '@/download-manager/download-manager.modul
     ModelRepositoryModule,
     DownloadManagerModule,
   ],
-  controllers: [ModelsController],
+  controllers: [],
   providers: [ModelsUsecases],
   exports: [ModelsUsecases],
 })

--- a/cortex-js/src/usecases/threads/threads.module.ts
+++ b/cortex-js/src/usecases/threads/threads.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ThreadsUsecases } from './threads.usecases';
-import { ThreadsController } from '@/infrastructure/controllers/threads.controller';
 import { DatabaseModule } from '@/infrastructure/database/database.module';
 
 @Module({
   imports: [DatabaseModule],
-  controllers: [ThreadsController],
+  controllers: [],
   providers: [ThreadsUsecases],
   exports: [ThreadsUsecases],
 })


### PR DESCRIPTION
## Describe Your Changes

This PR is intended to refactor the use cases to eliminate their dependency on controllers. According to the principles of the Clean Architecture, controllers should be defined at the app/framework level and not in the use cases.

This PR also added support for Cortex Serve with detach mode and additional status indicators in Cortex PS to display the API server's online status. Also added stop api server option `cortex serve stop`.


<img width="714" alt="Screenshot 2024-06-13 at 22 11 30" src="https://github.com/janhq/cortex/assets/133622055/7747565f-97a0-4e34-9290-6920db8f8e75">


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed