### PR TITLE
fix: cortex serve should run in attached mode by default

### DIFF
--- a/cortex-js/src/app.module.ts
+++ b/cortex-js/src/app.module.ts
@@ -26,6 +26,7 @@ import { ModelsController } from './infrastructure/controllers/models.controller
 import { ThreadsController } from './infrastructure/controllers/threads.controller';
 import { StatusController } from './infrastructure/controllers/status.controller';
 import { ProcessController } from './infrastructure/controllers/process.controller';
+import { DownloadManagerModule } from './download-manager/download-manager.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { ProcessController } from './infrastructure/controllers/process.controll
     FileManagerModule,
     TelemetryModule,
     UtilModule,
+    DownloadManagerModule,
   ],
   controllers: [
     AssistantsController,

--- a/cortex-js/src/infrastructure/commanders/serve.command.ts
+++ b/cortex-js/src/infrastructure/commanders/serve.command.ts
@@ -12,7 +12,7 @@ import { ServeStopCommand } from './sub-commands/serve-stop.command';
 type ServeOptions = {
   address?: string;
   port?: number;
-  attach: boolean;
+  detach: boolean;
 };
 
 @SubCommand({
@@ -36,7 +36,7 @@ export class ServeCommand extends CommandRunner {
   private async startServer(
     host: string,
     port: number,
-    options: ServeOptions = { attach: true },
+    options: ServeOptions = { detach: false },
   ) {
     const serveProcess = spawn(
       'node',
@@ -50,11 +50,11 @@ export class ServeCommand extends CommandRunner {
           CORTEX_JS_PORT: port.toString(),
           NODE_ENV: 'production',
         },
-        stdio: options?.attach ? 'inherit' : 'ignore',
+        stdio: options?.detach ? 'ignore' : 'inherit',
         detached: true,
       },
     );
-    if (!options?.attach) {
+    if (options?.detach) {
       serveProcess.unref();
       console.log('Started server at http://%s:%d', host, port);
     }
@@ -77,12 +77,12 @@ export class ServeCommand extends CommandRunner {
   }
 
   @Option({
-    flags: '-a, --attach',
-    description: 'Attach to interactive chat session',
+    flags: '-d, --detach',
+    description: 'Run the server in detached mode',
     defaultValue: false,
-    name: 'attach',
+    name: 'detach',
   })
-  parseAttach() {
+  parseDetach() {
     return true;
   }
 }


### PR DESCRIPTION
## Describe Your Changes

- As a user, when I run cortex serve, I would like to see it run in attached mode, allowing me to observe the incoming requests

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed