### PR TITLE
feat: ship ONNX runtime on Windows

### DIFF
--- a/cortex-js/src/infrastructure/commanders/models/model-pull.command.ts
+++ b/cortex-js/src/infrastructure/commanders/models/model-pull.command.ts
@@ -10,7 +10,8 @@ import { ModelNotFoundException } from '@/infrastructure/exception/model-not-fou
   aliases: ['download'],
   arguments: '<model_id>',
   argsDescription: { model_id: 'Model repo to pull' },
-  description: 'Download a model. Working with HuggingFace model id.',
+  description:
+    'Download a model from a registry. Working with HuggingFace repositories. For available models, please visit https://huggingface.co/cortexhub',
 })
 @SetCommandContext()
 export class ModelPullCommand extends CommandRunner {

--- a/cortex-js/src/infrastructure/commanders/usecases/init.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/init.cli.usecases.ts
@@ -301,7 +301,7 @@ export class InitCliUsecases {
    * @param engineFileName 
    */
   async installONNXEngine(
-    version: string = 'v0.1.1',
+    version: string = 'latest',
     engineFileName: string = 'windows-amd64',
   ) {
     const res = await firstValueFrom(

--- a/cortex-js/src/infrastructure/commanders/usecases/init.cli.usecases.ts
+++ b/cortex-js/src/infrastructure/commanders/usecases/init.cli.usecases.ts
@@ -1,4 +1,11 @@
-import { createWriteStream, existsSync, rmSync } from 'fs';
+import {
+  cpSync,
+  createWriteStream,
+  existsSync,
+  readdir,
+  readdirSync,
+  rmSync,
+} from 'fs';
 import { delimiter, join } from 'path';
 import { HttpService } from '@nestjs/axios';
 import { Presets, SingleBar } from 'cli-progress';
@@ -12,6 +19,7 @@ import { rm } from 'fs/promises';
 import { exec } from 'child_process';
 import { appPath } from '@/utils/app-path';
 import {
+  CORTEX_ONNX_ENGINE_RELEASES_URL,
   CORTEX_RELEASES_URL,
   CUDA_DOWNLOAD_URL,
 } from '@/infrastructure/constants/cortex';
@@ -59,7 +67,7 @@ export class InitCliUsecases {
       exit(1);
     }
 
-    console.log(`Downloading engine file ${engineFileName}`);
+    console.log(`Downloading Llama.cpp engine file ${engineFileName}`);
     const dataFolderPath = await this.fileManagerService.getDataFolderPath();
     const engineDir = join(dataFolderPath, 'cortex-cpp');
     if (existsSync(engineDir)) rmSync(engineDir, { recursive: true });
@@ -109,6 +117,9 @@ export class InitCliUsecases {
       exit(1);
     }
     await rm(destination, { force: true });
+
+    // Ship ONNX Runtime on Windows by default
+    if (process.platform === 'win32') await this.installONNXEngine();
   };
 
   parseEngineFileName = (options?: InitOptions) => {
@@ -187,6 +198,7 @@ export class InitCliUsecases {
     ).replace('<platform>', platform);
     const destination = join(dataFolderPath, 'cuda-toolkit.tar.gz');
 
+    console.log('Downloading CUDA Toolkit dependency...');
     const download = await firstValueFrom(
       this.httpService.get(url, {
         responseType: 'stream',
@@ -282,6 +294,109 @@ export class InitCliUsecases {
       );
     });
   };
+
+  /**
+   * Download and install ONNX engine
+   * @param version
+   * @param engineFileName 
+   */
+  async installONNXEngine(
+    version: string = 'v0.1.1',
+    engineFileName: string = 'windows-amd64',
+  ) {
+    const res = await firstValueFrom(
+      this.httpService.get(
+        CORTEX_ONNX_ENGINE_RELEASES_URL +
+          `${version === 'latest' ? '/latest' : ''}`,
+        {
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28',
+            Accept: 'application/vnd.github+json',
+          },
+        },
+      ),
+    );
+
+    if (!res?.data) {
+      console.log('Failed to fetch releases');
+      exit(1);
+    }
+
+    let release = res?.data;
+    if (Array.isArray(res?.data)) {
+      release = Array(res?.data)[0].find(
+        (e) => e.name === version.replace('v', ''),
+      );
+    }
+    const toDownloadAsset = release.assets.find((s: any) =>
+      s.name.includes(engineFileName),
+    );
+
+    if (!toDownloadAsset) {
+      console.log(`Could not find engine file ${engineFileName}`);
+      exit(1);
+    }
+
+    console.log(`Downloading ONNX engine file ${engineFileName}`);
+    const dataFolderPath = await this.fileManagerService.getDataFolderPath();
+    const engineDir = join(dataFolderPath, 'cortex-cpp');
+
+    const download = await firstValueFrom(
+      this.httpService.get(toDownloadAsset.browser_download_url, {
+        responseType: 'stream',
+      }),
+    );
+    if (!download) {
+      console.log('Failed to download model');
+      process.exit(1);
+    }
+
+    const destination = join(dataFolderPath, toDownloadAsset.name);
+
+    await new Promise((resolve, reject) => {
+      const writer = createWriteStream(destination);
+      let receivedBytes = 0;
+      const totalBytes = download.headers['content-length'];
+
+      writer.on('finish', () => {
+        bar.stop();
+        resolve(true);
+      });
+
+      writer.on('error', (error) => {
+        bar.stop();
+        reject(error);
+      });
+
+      const bar = new SingleBar({}, Presets.shades_classic);
+      bar.start(100, 0);
+
+      download.data.on('data', (chunk: any) => {
+        receivedBytes += chunk.length;
+        bar.update(Math.floor((receivedBytes / totalBytes) * 100));
+      });
+
+      download.data.pipe(writer);
+    });
+
+    try {
+      await decompress(destination, join(engineDir, 'engines'));
+    } catch (e) {
+      console.error('Error decompressing file', e);
+      exit(1);
+    }
+    await rm(destination, { force: true });
+
+    // Copy the additional files to the cortex-cpp directory
+    for (const file of readdirSync(join(engineDir, 'engines', 'cortex.onnx'))) {
+      if (file !== 'engine.dll') {
+        await cpSync(
+          join(engineDir, 'engines', 'cortex.onnx', file),
+          join(engineDir, file),
+        );
+      }
+    }
+  }
 
   private checkFileExistenceInPaths = (
     file: string,

--- a/cortex-js/src/infrastructure/constants/cortex.ts
+++ b/cortex-js/src/infrastructure/constants/cortex.ts
@@ -42,6 +42,9 @@ export const CORTEX_JS_STOP_API_SERVER_URL = (
 export const CORTEX_RELEASES_URL =
   'https://api.github.com/repos/janhq/cortex/releases';
 
+export const CORTEX_ONNX_ENGINE_RELEASES_URL =
+  'https://api.github.com/repos/janhq/cortex.onnx/releases';
+
 export const CUDA_DOWNLOAD_URL =
   'https://catalog.jan.ai/dist/cuda-dependencies/<version>/<platform>/cuda.tar.gz';
 

--- a/cortex-js/src/infrastructure/constants/huggingface.ts
+++ b/cortex-js/src/infrastructure/constants/huggingface.ts
@@ -2,7 +2,7 @@ export const HUGGING_FACE_TREE_REF_URL = (
   repo: string,
   tree: string,
   path: string,
-) => `https://huggingface.co/janhq/${repo}/resolve/${tree}/${path}`;
+) => `https://huggingface.co/cortexhub/${repo}/resolve/${tree}/${path}`;
 
 export const HUGGING_FACE_DOWNLOAD_FILE_MAIN_URL = (
   author: string,

--- a/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
+++ b/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
@@ -15,7 +15,7 @@ import { FileManagerService } from '@/infrastructure/services/file-manager/file-
 
 @Injectable()
 export default class CortexProvider extends OAIEngineExtension {
-  provider: string = 'cortex.llamacpp';
+  provider: string = 'cortex';
   apiUrl = `http://${defaultCortexCppHost}:${defaultCortexCppPort}/inferences/server/chat_completion`;
 
   private loadModelUrl = `http://${defaultCortexCppHost}:${defaultCortexCppPort}/inferences/server/loadmodel`;

--- a/cortex-js/src/infrastructure/repositories/extensions/extension.repository.ts
+++ b/cortex-js/src/infrastructure/repositories/extensions/extension.repository.ts
@@ -11,7 +11,10 @@ import { existsSync } from 'fs';
 @Injectable()
 export class ExtensionRepositoryImpl implements ExtensionRepository {
   // Initialize the Extensions Map with the key-value pairs of the core providers.
-  extensions = new Map<string, Extension>([['cortex', this.cortexProvider]]);
+  extensions = new Map<string, Extension>([
+    ['cortex.llamacpp', this.cortexProvider],
+    ['cortex.onnx', this.cortexProvider],
+  ]);
 
   constructor(
     @Inject('CORTEX_PROVIDER')

--- a/cortex-js/src/usecases/chat/chat.usecases.ts
+++ b/cortex-js/src/usecases/chat/chat.usecases.ts
@@ -25,15 +25,14 @@ export class ChatUsecases {
     headers: Record<string, string>,
   ): Promise<any> {
     const { model: modelId } = createChatDto;
-    const extensions = (await this.extensionRepository.findAll()) ?? [];
     const model = await this.modelRepository.findOne(modelId);
 
     if (!model) {
       throw new ModelNotFoundException(modelId);
     }
-    const engine = extensions.find((e: any) => e.provider === model?.engine) as
-      | EngineExtension
-      | undefined;
+    const engine = (await this.extensionRepository.findOne(
+      model!.engine ?? 'cortex.llamacpp',
+    )) as EngineExtension | undefined;
 
     if (engine == null) {
       throw new Error(`No engine found with name: ${model.engine}`);

--- a/cortex-js/src/utils/huggingface.ts
+++ b/cortex-js/src/utils/huggingface.ts
@@ -64,6 +64,7 @@ export function guessPromptTemplateFromHuggingFace(jinjaCode?: string): string {
 export async function fetchHuggingFaceRepoData(
   repoId: string,
 ): Promise<HuggingFaceRepoData> {
+
   const sanitizedUrl = getRepoModelsUrl(repoId);
 
   const { data: response } = await axios.get(sanitizedUrl);
@@ -113,7 +114,8 @@ export async function fetchJanRepoData(
 ): Promise<HuggingFaceRepoData> {
   const repo = modelId.split(':')[0];
   const tree = modelId.split(':')[1] ?? 'default';
-  const url = getRepoModelsUrl(`janhq/${repo}`, tree);
+  const url = getRepoModelsUrl(`cortexhub/${repo}`, tree);
+
   const res = await fetch(url);
   const response:
     | {
@@ -140,7 +142,7 @@ export async function fetchJanRepoData(
     tags: ['gguf'],
     id: modelId,
     modelId: modelId,
-    author: 'janhq',
+    author: 'cortexhub',
     sha: '',
     downloads: 0,
     lastModified: '',
@@ -161,6 +163,9 @@ export async function fetchJanRepoData(
   });
 
   data.modelUrl = url;
+
+  
+  
   return data;
 }
 
@@ -199,7 +204,7 @@ export async function getHFModelMetadata(
       version,
     };
   } catch (err) {
-    console.log('Failed to get model metadata:', err);
+    console.log('Failed to get model metadata:', err.message);
     return undefined;
   }
 }


### PR DESCRIPTION
## Describe Your Changes

- This PR ships the ONNX runtime on Windows:
  - The ONNX engine is quite lightweight (14mb), so we've opted to bundle it alongside the llama.cpp engine.
  - Post-install step would download both engines to cortex directory.
  - During installation, a few files that do not belong to the engine will be moved accordingly by cortex-cpp.

NOTES: Since this PR, we have switched to using `cortexhub` as our default hub instead of the janhq HF repo

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed