### PR TITLE
feat: add inno installer script

### DIFF
--- a/cortex-js/installer.iss
+++ b/cortex-js/installer.iss
@@ -1,0 +1,41 @@
+; Inno Setup Script
+; Define the application name, version, and other details
+[Setup]
+AppName=Cortex
+AppVersion=1.0
+DefaultDirName={pf}\Cortex
+DefaultGroupName=Cortex
+OutputDir=.
+OutputBaseFilename=setup
+Compression=lzma
+SolidCompression=yes
+PrivilegesRequired=admin
+
+; Define the languages section
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+; Define the files to be installed
+[Files]
+Source: "cortex.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "node_modules\sqlite3\*"; DestDir: "{app}\node_modules\sqlite3"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+; Define the icons to be created
+[Icons]
+Name: "{group}\Cortex"; Filename: "{app}\cortex.exe"
+
+; Define the run section to execute the application after installation
+[Run]
+Filename: "cmd"; Parameters: "/c setx PATH ""%PATH%;{app}"""; StatusMsg: "Updating system PATH environment variable..."; Flags: runhidden
+Filename: "cmd"; Parameters: "/c cortex init"; StatusMsg: "Initializing Cortex..."; Flags: runhidden waituntilterminated
+Filename: "{app}\cortex.exe"; Description: "{cm:LaunchProgram,Cortex}"; Flags: nowait postinstall skipifsilent
+
+; Define the tasks section (optional, for additional tasks like creating desktop icons)
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop icon"; GroupDescription: "Additional icons:"; Flags: unchecked
+Name: "quicklaunchicon"; Description: "Create a &Quick Launch icon"; GroupDescription: "Additional icons:"; Flags: unchecked
+
+; Define icons for the additional tasks
+[Icons]
+Name: "{commondesktop}\Cortex"; Filename: "{app}\cortex.exe"; Tasks: desktopicon
+Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\Cortex"; Filename: "{app}\cortex.exe"; Tasks: quicklaunchicon

--- a/cortex-js/package.json
+++ b/cortex-js/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "nest dev",
     "build": "yarn build:extensions && nest build && cpx \"cpuinfo/bin/**\" dist/bin",
-    "build:binary": "yarn build && nexe dist/src/command.js --build --python=$(which python3) -o dist/cortex",
+    "build:binary": "yarn build && nexe dist/src/command.js --build -r './node_modules/**/*' -o dist/cortex",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "build:extensions": "run-script-os",
     "build:extensions:windows": "powershell -command \"$jobs = Get-ChildItem -Path './src/extensions' -Directory | ForEach-Object { Start-Job -Name ($_.Name) -ScriptBlock { param($_dir); try { Set-Location $_dir; yarn; yarn build; Write-Output 'Build successful in ' + $_dir } catch { Write-Error 'Error in ' + $_dir; throw } } -ArgumentList $_.FullName }; $jobs | Wait-Job; $jobs | ForEach-Object { Receive-Job -Job $_ -Keep } | ForEach-Object { Write-Host $_ }; $failed = $jobs | Where-Object { $_.State -ne 'Completed' -or $_.ChildJobs[0].JobStateInfo.State -ne 'Completed' }; if ($failed) { Exit 1 }\"",


### PR DESCRIPTION
## Describe Your Changes

- Enable Cortex distribution on Windows using an MSI installer

Notes: 
- The installation step adds the Cortex location to the PATH environment variable and installs required dependencies (via "cortex init").

![Cortex Install UX Screenshot June 19](https://github.com/janhq/cortex/assets/133622055/cc0da942-b280-4ab7-8854-00f0f6531a35)


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed