### PR TITLE
fix: resolve deprecated module npm

### DIFF
--- a/cortex-js/package.json
+++ b/cortex-js/package.json
@@ -110,6 +110,9 @@
     "ajv": "8.15.0",
     "whatwg-url": "14.0.0"
   },
+  "overrides": {
+    "whatwg-url": "14.x"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Describe Your Changes

(node:66516) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed