### PR TITLE
chore: #754 - add help information into root commands

### DIFF
--- a/cortex-cpp/README.md
+++ b/cortex-cpp/README.md
@@ -163,7 +163,7 @@ Below is the available list of the model parameters you can set when loading a m
 
 
 ## Manual Build
-Manual build is a process in which the developers build the software manually. This is usually done when a new feature is implemented, or a bug is fixed. The process for this project is defined in [`.github/workflows/build.yml`](.github/workflows/build.yml)
+Manual build is a process in which the developers build the software manually. This is usually done when a new feature is implemented, or a bug is fixed. The process for this project is defined in [`.github/workflows/cortex-build.yml`](../.github/workflows/cortex-build.yml)
 
 ## Contact Support
 

--- a/cortex-js/src/infrastructure/commanders/configs.command.ts
+++ b/cortex-js/src/infrastructure/commanders/configs.command.ts
@@ -8,11 +8,7 @@ import { ConfigsSetCommand } from './configs/configs-set.command';
 @SubCommand({
   name: 'configs',
   description: 'Get cortex configurations',
-  arguments: '<name>',
   subCommands: [ConfigsGetCommand, ConfigsListCommand, ConfigsSetCommand],
-  argsDescription: {
-    name: 'Configuration name to get',
-  },
 })
 @SetCommandContext()
 export class ConfigsCommand extends CommandRunner {
@@ -20,5 +16,7 @@ export class ConfigsCommand extends CommandRunner {
     super();
   }
 
-  async run(): Promise<void> {}
+  async run(): Promise<void> {
+    this.command?.help();
+  }
 }

--- a/cortex-js/src/infrastructure/commanders/engines.command.ts
+++ b/cortex-js/src/infrastructure/commanders/engines.command.ts
@@ -16,5 +16,7 @@ export class EnginesCommand extends CommandRunner {
     super();
   }
 
-  async run(): Promise<void> {}
+  async run(): Promise<void> {
+    this.command?.help();
+  }
 }

--- a/cortex-js/src/infrastructure/commanders/models.command.ts
+++ b/cortex-js/src/infrastructure/commanders/models.command.ts
@@ -23,5 +23,7 @@ import { RunCommand } from './shortcuts/run.command';
   description: 'Subcommands for managing models',
 })
 export class ModelsCommand extends CommandRunner {
-  async run(): Promise<void> {}
+  async run(): Promise<void> {
+    this.command?.help();
+  }
 }

--- a/cortex-js/src/infrastructure/commanders/models/model-list.command.ts
+++ b/cortex-js/src/infrastructure/commanders/models/model-list.command.ts
@@ -22,6 +22,7 @@ export class ModelListCommand extends CommandRunner {
       ? console.table(
           models.map((e) => ({
             id: e.model,
+            name: e.name,
             engine: e.engine,
             version: e.version,
           })),


### PR DESCRIPTION
## Describe Your Changes

This is to add help information when users access root commands (models, engines, configs)

<img width="1103" alt="image" src="https://github.com/janhq/cortex/assets/133622055/f72fc4ad-90a4-4d96-8614-c540bc508a73">


<img width="1103" alt="image" src="https://github.com/janhq/cortex/assets/133622055/5d8b6156-bafa-4207-a9f6-4b72360d0e7b">

`cortex models list` should show model name

<img width="1103" alt="image" src="https://github.com/janhq/cortex/assets/133622055/2b010ddd-adc3-42d5-9078-c0b1069a198b">


## Fixes Issues

- Closes #754
- Closes #836 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed