### PR TITLE
fix: missing swagger UI assets on prebuilt binaries

### DIFF
--- a/cortex-js/package.json
+++ b/cortex-js/package.json
@@ -140,7 +140,8 @@
     "assets": [
       "command/*.node",
       "**/package.json",
-      "node_modules/axios/**/*"
+      "node_modules/axios/**/*",
+      "node_modules/swagger-ui-dist/"
     ],
     "outputPath": "dist"
   }


### PR DESCRIPTION
## Describe Your Changes

- Playground is broken on prebuilt binaries & installers

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed