### PR TITLE
fix: chat completion endpoint is hang

### DIFF
--- a/cortex-js/src/domain/abstracts/oai.abstract.ts
+++ b/cortex-js/src/domain/abstracts/oai.abstract.ts
@@ -20,7 +20,6 @@ export abstract class OAIEngineExtension extends EngineExtension {
   ): Promise<stream.Readable | any> {
     const payload = this.transformPayload ? this.transformPayload(createChatDto) : createChatDto;
     const { stream: isStream } = payload;
-    const contentType = headers['content-type'] ?? 'application/json';
     const additionalHeaders = _.omit(headers, [
       'content-type',
       'authorization',

--- a/cortex-js/src/domain/abstracts/oai.abstract.ts
+++ b/cortex-js/src/domain/abstracts/oai.abstract.ts
@@ -20,7 +20,12 @@ export abstract class OAIEngineExtension extends EngineExtension {
   ): Promise<stream.Readable | any> {
     const payload = this.transformPayload ? this.transformPayload(createChatDto) : createChatDto;
     const { stream: isStream } = payload;
-    const additionalHeaders = _.omit(headers, ['content-type', 'authorization']);
+    const contentType = headers['content-type'] ?? 'application/json';
+    const additionalHeaders = _.omit(headers, [
+      'content-type',
+      'authorization',
+      'content-length'
+    ]);
     const response = await firstValueFrom(
       this.httpService.post(this.apiUrl, payload, {
         headers: {
@@ -33,11 +38,11 @@ export abstract class OAIEngineExtension extends EngineExtension {
         responseType: isStream ? 'stream' : 'json',
       }),
     );
-    
+
     if (!response) {
       throw new Error('No response');
     }
-    if(!this.transformResponse) {
+    if (!this.transformResponse) {
       return response.data;
     }
     if (isStream) {
@@ -55,7 +60,7 @@ export abstract class OAIEngineExtension extends EngineExtension {
             }
           }
           callback(null, transformedLines.join(''));
-        }
+        },
       });
       return response.data.pipe(lineStream);
     }

--- a/cortex-js/src/extensions/anthropic.engine.ts
+++ b/cortex-js/src/extensions/anthropic.engine.ts
@@ -37,8 +37,6 @@ export default class AnthropicEngineExtension extends OAIEngineExtension {
       this.name,
     )) as unknown as { apiKey: string };
     this.apiKey = configs?.apiKey;
-    if (!configs?.apiKey)
-      await this.configsUsecases.saveConfig('apiKey', '', this.name);
   }
 
   override async inference(dto: any, headers: Record<string, string>): Promise<stream.Readable | any> {

--- a/cortex-js/src/extensions/groq.engine.ts
+++ b/cortex-js/src/extensions/groq.engine.ts
@@ -36,7 +36,5 @@ export default class GroqEngineExtension extends OAIEngineExtension {
     )) as unknown as { apiKey: string };
 
     this.apiKey = configs?.apiKey;
-    if (!configs?.apiKey)
-      await this.configsUsecases.saveConfig('apiKey', '', this.name);
   }
 }

--- a/cortex-js/src/extensions/mistral.engine.ts
+++ b/cortex-js/src/extensions/mistral.engine.ts
@@ -35,7 +35,5 @@ export default class MistralEngineExtension extends OAIEngineExtension {
       this.name,
     )) as unknown as { apiKey: string };
     this.apiKey = configs?.apiKey;
-    if (!configs?.apiKey)
-      await this.configsUsecases.saveConfig('apiKey', '', this.name);
   }
 }

--- a/cortex-js/src/extensions/openai.engine.ts
+++ b/cortex-js/src/extensions/openai.engine.ts
@@ -35,7 +35,5 @@ export default class OpenAIEngineExtension extends OAIEngineExtension {
       this.name,
     )) as unknown as { apiKey: string };
     this.apiKey = configs?.apiKey;
-    if (!configs?.apiKey)
-      await this.configsUsecases.saveConfig('apiKey', '', this.name);
   }
 }


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where all requests route to /v1/chat/completions are not processed. They all hang due to the hard-coded content-size of the request header modification.

- Broken PR: #864

## Fixes Issues

- Closes #876

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed