### PR TITLE
fix: download model wrong event mits

### DIFF
--- a/cortex-js/src/infrastructure/services/download-manager/download-manager.service.ts
+++ b/cortex-js/src/infrastructure/services/download-manager/download-manager.service.ts
@@ -34,7 +34,7 @@ export class DownloadManagerService {
     this.allDownloadStates = this.allDownloadStates.filter(
       (downloadState) => downloadState.id !== downloadId,
     );
-    this.eventEmitter.emit('download.event.aborted', this.allDownloadStates);
+    this.eventEmitter.emit('download.event', this.allDownloadStates);
   }
 
   async submitDownloadRequest(


### PR DESCRIPTION
## Describe Your Changes

There was a legacy issue where we combined abort download event and progress event into 1 pipeline.

Download: +------A1-------A2--------A3---X
Cancel     : +---B1-----B2-------B3---------X

Problems: 
1. We use a throttle without trailing event emission.
- At X, there is no A3 event emitted (e.g., 100% or success event).
2. We add a trailing event emission.
- At A2, we abort the download process -> a B1 event is emitted, then A2 once (aborted -> downloading).


## Fixes Issues

- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed