### PR TITLE
chore: fixed an issue where cortex chat reload the running models

### DIFF
--- a/cortex-js/src/infrastructure/commanders/chat.command.ts
+++ b/cortex-js/src/infrastructure/commanders/chat.command.ts
@@ -109,21 +109,19 @@ export class ChatCommand extends BaseCommand {
 
     const preset = await this.fileService.getPreset(options.preset);
       
-    return this.cortex.models.start(modelId, preset).then(() =>
-      this.chatClient.chat(
+    return this.chatClient.chat(
         modelId,
         options.threadId,
         message, // Accept both message from inputs or arguments
         preset ? preset : {},
-      ),
-    );
+      )
   }
 
   modelInquiry = async (models: Cortex.Model[]) => {
     const { model } = await this.inquirerService.inquirer.prompt({
       type: 'list',
       name: 'model',
-      message: 'Select running model to chat with:',
+      message: 'Select a model to chat with:',
       choices: models.map((e) => ({
         name: e.id,
         value: e.id,

--- a/cortex-js/src/infrastructure/commanders/embeddings.command.ts
+++ b/cortex-js/src/infrastructure/commanders/embeddings.command.ts
@@ -71,7 +71,7 @@ export class EmbeddingCommand extends BaseCommand {
     const { model } = await this.inquirerService.inquirer.prompt({
       type: 'list',
       name: 'model',
-      message: 'Select running model to chat with:',
+      message: 'Select model to chat with:',
       choices: models.map((e) => ({
         name: e.id,
         value: e.id,


### PR DESCRIPTION
## Describe Your Changes

- Cortex chat should attach session into running models only. Or chat completion endpoint start model automatically (it's backend stuff not frontend)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed