### PR TITLE
fix: cortex engines init api with empty body should init default options

### DIFF
--- a/cortex-js/src/usecases/engines/engines.usecase.ts
+++ b/cortex-js/src/usecases/engines/engines.usecase.ts
@@ -23,7 +23,7 @@ import { CommonResponseDto } from '@/infrastructure/dtos/common/common-response.
 import { EngineStatus } from '@/domain/abstracts/engine.abstract';
 import { ConfigsUsecases } from '../configs/configs.usecase';
 import { defaultInstallationOptions } from '@/utils/init';
-
+import { isEmpty } from "lodash"
 @Injectable()
 export class EnginesUsecases {
   constructor(
@@ -79,7 +79,7 @@ export class EnginesUsecases {
   ): Promise<any> => {
     // Use default option if not defined
 
-    if (!options && engine === Engines.llamaCPP) {
+    if ((!options || isEmpty(options)) && engine === Engines.llamaCPP) {
       options = await defaultInstallationOptions();
     }
     const installPackages = [];


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where client sends empty body should also provide best default engine init options

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed