### PR TITLE
fix: create message request with string content instead of array

### DIFF
--- a/cortex-js/src/infrastructure/commanders/services/chat-client.ts
+++ b/cortex-js/src/infrastructure/commanders/services/chat-client.ts
@@ -103,12 +103,7 @@ export class ChatClient {
 
     const createMessageDto: Cortex.Beta.Threads.Messages.MessageCreateParams = {
       role: 'user',
-      content: [
-        {
-          type: 'text',
-          text: userInput,
-        },
-      ],
+      content: userInput,
     };
     this.cortex.beta.threads.messages.create(threadId, createMessageDto);
 
@@ -145,12 +140,7 @@ export class ChatClient {
       this.cortex.beta.threads.messages
         .create(threadId, {
           role: 'assistant',
-          content: [
-            {
-              type: 'text',
-              text: assistantResponse,
-            },
-          ],
+          content: assistantResponse,
         })
         .then(() => {
           assistantResponse = '';


### PR DESCRIPTION
## Describe Your Changes

- This is to normalize message content request, since jan is not handled message content array type yet. 

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed