### PR TITLE
fix: persists engine version on init

### DIFF
--- a/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
+++ b/cortex-js/src/infrastructure/providers/cortex/cortex.provider.ts
@@ -13,6 +13,7 @@ import { readdirSync } from 'node:fs';
 import { normalizeModelId } from '@/utils/normalize-model-id';
 import { firstValueFrom } from 'rxjs';
 import { fileManagerService } from '@/infrastructure/services/file-manager/file-manager.service';
+import { existsSync, readFileSync } from 'fs';
 
 export interface ModelStatResponse {
   object: string;
@@ -34,6 +35,7 @@ export default class CortexProvider extends OAIEngineExtension {
 
   constructor(protected readonly httpService: HttpService) {
     super(httpService);
+    this.persistEngineVersion();
   }
 
   // Override the inference method to make an inference request to the engine
@@ -161,5 +163,15 @@ export default class CortexProvider extends OAIEngineExtension {
 
     // Return an error if none of the conditions are met
     return { error: 'Cannot split prompt template' };
+  };
+
+  private persistEngineVersion = async () => {
+    const versionFilePath = join(
+      await fileManagerService.getCortexCppEnginePath(),
+      this.name,
+      'version.txt',
+    );
+    if (existsSync(versionFilePath))
+      this.version = readFileSync(versionFilePath, 'utf-8');
   };
 }

--- a/cortex-js/src/infrastructure/repositories/extensions/extension.repository.ts
+++ b/cortex-js/src/infrastructure/repositories/extensions/extension.repository.ts
@@ -32,7 +32,7 @@ export class ExtensionRepositoryImpl implements ExtensionRepository {
     // Watch engine folder only for now
     fileManagerService.getCortexCppEnginePath().then((path) => {
       if (!existsSync(path)) mkdirSync(path);
-      watch(path, (eventType, filename) => {
+      watch(path, () => {
         this.extensions.clear();
         this.loadCoreExtensions();
         this.loadExternalExtensions();


### PR DESCRIPTION
## Describe Your Changes

- This PR is to persist the engine version and display it accordingly, instead of just returning a hardcoded version.

<img width="1893" alt="Screenshot 2024-08-04 at 22 16 03" src="https://github.com/user-attachments/assets/caa421c6-eb70-43e3-869b-c5e1df434448">


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed