### PR TITLE
fix: incorrect used ram report

### DIFF
--- a/cortex-js/src/infrastructure/services/resources-manager/resources-manager.service.ts
+++ b/cortex-js/src/infrastructure/services/resources-manager/resources-manager.service.ts
@@ -15,7 +15,7 @@ export class ResourcesManagerService {
     const memory = results[1] as Systeminformation.MemData;
     const memInfo: UsedMemInfo = {
       total: memory.total,
-      used: memory.used,
+      used: memory.active,
     };
 
     return {


### PR DESCRIPTION
## Describe Your Changes

- When pulling resources information via API, it returns incorrect active RAM 
<img width="1230" alt="Screenshot 2024-08-08 at 21 31 32" src="https://github.com/user-attachments/assets/a7568c8d-7815-4768-9af6-25d0386ff4fe">


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed