### PR TITLE
chore: system resource events should include gpu system information

### DIFF
--- a/cortex-js/src/domain/models/resource.interface.ts
+++ b/cortex-js/src/domain/models/resource.interface.ts
@@ -7,9 +7,15 @@ export interface ResourceStatus {
   cpu: {
     usage: number;
   };
+  gpus: GpuInfo[];
 }
 
 export interface UsedMemInfo {
   total: number;
   used: number;
+}
+
+export interface GpuInfo {
+  name: string | undefined;
+  vram: number | null;
 }

--- a/cortex-js/src/infrastructure/services/resources-manager/resources-manager.service.ts
+++ b/cortex-js/src/infrastructure/services/resources-manager/resources-manager.service.ts
@@ -1,16 +1,15 @@
-import osUtils from 'node-os-utils'
 import {
   ResourceStatus,
   UsedMemInfo,
 } from '@/domain/models/resource.interface';
 import { getMemoryInformation, MemoryInformation } from '@/utils/system-resource';
 import { Injectable } from '@nestjs/common';
-import systemInformation, { Systeminformation } from 'systeminformation';
+import si, { Systeminformation } from 'systeminformation';
 
 @Injectable()
 export class ResourcesManagerService {
   async getResourceStatuses(): Promise<ResourceStatus> {
-    const promises = [systemInformation.currentLoad(), getMemoryInformation()];
+    const promises = [si.currentLoad(), getMemoryInformation()];
     const results = await Promise.all(promises);
 
     const cpuUsage = results[0] as Systeminformation.CurrentLoadData;
@@ -19,12 +18,15 @@ export class ResourcesManagerService {
       total: memory.total,
       used: memory.used,
     };
-
     return {
       mem: memInfo,
       cpu: {
         usage: Number(cpuUsage.currentLoad.toFixed(2)),
       },
+      gpus: (await si.graphics()).controllers.map((gpu) => ({
+        name: gpu.name,
+        vram: gpu.vram,
+      })),
     };
   }
 }

--- a/cortex-js/src/usecases/models/models.usecases.ts
+++ b/cortex-js/src/usecases/models/models.usecases.ts
@@ -513,7 +513,7 @@ export class ModelsUsecases {
 
       // Default Inference Params
       stream: true,
-      max_tokens: 4098,
+      max_tokens: 4096,
       frequency_penalty: 0.7,
       presence_penalty: 0.7,
       temperature: 0.7,


### PR DESCRIPTION
## Describe Your Changes

- /system/events/resources should return GPUs information
<img width="640" alt="Screenshot 2024-08-12 165638" src="https://github.com/user-attachments/assets/8edd9247-4c6d-4048-a938-360682757d13">

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed