### PR TITLE
chore: fallback noavx binary

### DIFF
--- a/cortex-js/package.json
+++ b/cortex-js/package.json
@@ -59,7 +59,6 @@
     "class-validator": "^0.14.1",
     "cli-progress": "^3.12.0",
     "cortex-cpp": "0.5.0-40",
-    "cpu-instructions": "^0.0.11",
     "decompress": "^4.2.1",
     "hyllama": "^0.2.2",
     "js-yaml": "^4.1.0",

--- a/cortex-js/src/usecases/engines/engines.usecase.ts
+++ b/cortex-js/src/usecases/engines/engines.usecase.ts
@@ -101,8 +101,8 @@ export class EnginesUsecases {
               ? '-mac'
               : '-linux',
           // CPU Instructions - CPU | GPU Non-Vulkan
-          options?.instructions && !isVulkan
-            ? `-${options?.instructions?.toLowerCase()}`
+          !isVulkan
+            ? `-noavx`
             : '',
           // Cuda
           options?.runMode === 'GPU' &&

--- a/cortex-js/src/utils/init.ts
+++ b/cortex-js/src/utils/init.ts
@@ -1,5 +1,4 @@
 import { InitOptions } from '@/infrastructure/commanders/types/init-options.interface';
-import { cpuInfo } from 'cpu-instructions';
 import { checkNvidiaGPUExist } from './cuda';
 
 /**
@@ -16,15 +15,5 @@ export const defaultInstallationOptions = async (): Promise<InitOptions> => {
   // If Nvidia Driver is installed -> GPU
   options.runMode = (await checkNvidiaGPUExist()) ? 'GPU' : 'CPU';
   options.gpuType = 'Nvidia';
-  //CPU Instructions detection
-  options.instructions = await detectInstructions();
   return options;
-};
-
-const detectInstructions = (): Promise<
-  'AVX' | 'AVX2' | 'AVX512' | undefined
-> => {
-  const cpuInstruction = cpuInfo.cpuInfo()[0] ?? 'AVX';
-  console.log(cpuInstruction, 'CPU instructions detected');
-  return Promise.resolve(cpuInstruction);
 };


### PR DESCRIPTION
## Describe Your Changes

- Follow up PR of [#avx](https://github.com/janhq/cortex.llamacpp/pull/172)

As agreed, there is little difference between CPU instructions when running the Cortex CPP benchmark. We revert to the no-AVX binary and rely on GPU performance.
 
## Fixes Issues

- Closes #899 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed